### PR TITLE
don't dereference a null object

### DIFF
--- a/components/class-go-sphinx.php
+++ b/components/class-go-sphinx.php
@@ -480,16 +480,14 @@ class GO_Sphinx
 			$this->search_stats['sphinx_results'] = $results;
 		}
 
-		if ( isset( $results['matches'] ) )
-		{
-			$this->matched_posts = array_keys( $results['matches'] );
-			$this->total_found = $results['total_found'];
-			return array_slice( $this->matched_posts , 0, $this->posts_per_page );
-		}
-		else
+		if ( ! isset( $results['matches'] ) )
 		{
 			return array();
 		}
+
+		$this->matched_posts = array_keys( $results['matches'] );
+		$this->total_found = $results['total_found'];
+		return array_slice( $this->matched_posts , 0, $this->posts_per_page );
 	}
 
 	/**


### PR DESCRIPTION
the change was to populate the debug stats first, then either return a slice of the results array or an empty array.
