### PR TITLE
added a decision log

### DIFF
--- a/components/class-go-sphinx.php
+++ b/components/class-go-sphinx.php
@@ -84,14 +84,18 @@ class GO_Sphinx
 	);
 	// supported orderby keywords
 	public $supported_order_by = array(
-		'none',
-		'ID',
-		'title',
-		'date',
-		'modified',
-		'parent',
-		'rand',
 		'comment_count',
+		'date',
+		'post_date',
+		'ID',
+		'modified',
+		'post_modified',
+		'none',
+		'parent',
+		'post_parent',
+		'rand',
+		'title',
+		'post_title',
 	);
 
 	public function __construct()


### PR DESCRIPTION
We're seeing a surprising number of complex MySQL queries that I'd expect to have been executed on Sphinx instead. Some of these queries take minutes to execute, so it's really important to keep them off MySQL.

This keeps a log of decisions, and in cases where the plugin is not used to execute the query, it logs to error.

Three query vars that were preventing Sphinx from answering a number of requests:
- `feed`
- `no_found_rows`
- `tag`

The first two had no effect on the results returned, the third is represented in the current taxonomy query handlers. I've whitelisted these three.

Addendum: more query and order_by vars added. See inline comments.
