### PR TITLE
check for error in the value of a result returned by reference

### DIFF
--- a/components/class-go-sphinx.php
+++ b/components/class-go-sphinx.php
@@ -764,6 +764,8 @@ class GO_Sphinx
 				$wp_query->tax_query->transform_query( $query, 'term_taxonomy_id' );
 				if ( is_wp_error( $query ) )
 				{
+					//TODO: report back that one or more requested terms
+					// were excluded from the search criteria
 					$this->messages[] = 'WP_Tax_Query::transform_query() returned an error: ' . print_r( $query, TRUE );
 					continue;
 				}


### PR DESCRIPTION
the call to `WP_Tax_Query::transform_query()` can return an error in the first parameter by reference, which wasn't being checked.

see https://github.com/GigaOM/legacy-pro/issues/2636
