### PR TITLE
removed a redundant author query term

### DIFF
--- a/components/class-go-sphinx.php
+++ b/components/class-go-sphinx.php
@@ -624,6 +624,11 @@ class GO_Sphinx
 	 */
 	public function sphinx_query_author( $wp_query )
 	{
+		if ( ! $wp_query->is_author )
+		{
+			return NULL;
+		}
+
 		if ( isset( $wp_query->query['author'] ) || isset( $wp_query->query['author_name'] ) )
 		{
 			$author_id = -1;    // default must be an invalid author id


### PR DESCRIPTION
do not add a sphinxql author query term if the incoming $wp_query's is_author flag is set to FALSE, which is the case if sphinx already converted an author query to an author taxonomy query.

see https://github.com/GigaOM/legacy-pro/issues/2045
