### PR TITLE
fixed over-escaped single quotes in search query strings

### DIFF
--- a/components/class-go-sphinx.php
+++ b/components/class-go-sphinx.php
@@ -933,11 +933,11 @@ class GO_Sphinx
 			return '';
 		}
 
-		// strip out escaping backslashes added by WP, urldecode/trim
-		// the query string so sphinx sees the original query. (not using
-		// wp_kses() here because the query string is not going to be
-		// consumed by a browser.)
-		return '@(post_content,content) ' . trim( urldecode( stripslashes( $wp_query->query['s'] ) ) );
+		// the keyword string is already escaped by WP (backslashes, quotes,
+		// etc.). we just have to trim the query string before feeding it
+		// into sphinxql. (not using wp_kses() here because the query string
+		// is not going to be consumed by a browser but by sphinx.)
+		return '@(post_content,content) ' . trim( $wp_query->query['s'] );
 	}//END sphinx_query_keyword
 
 	/**


### PR DESCRIPTION
extra slashes are already removed by WP by the time we get the query string

see https://github.com/GigaOM/legacy-pro/issues/2794
