### PR TITLE
allow go-sphinx to handle wp queries from widgets

### DIFF
--- a/components/class-go-sphinx.php
+++ b/components/class-go-sphinx.php
@@ -70,8 +70,8 @@ class GO_Sphinx
 		'tag_slug__and',
 		'tax_query',
 
-		/* these are allowed to pass through either because we allow them
-		   or because they're alternate keys used by WP */
+		// these are allowed to pass through either because we allow them
+		// or because they're alternate keys used by WP
 		'exclude',
 		'feed',
 		'fields',


### PR DESCRIPTION
these queries contain a wijax query_var that I think can be ignored as far as fetching posts is concerned.

one of the commits said it was for ticket https://github.com/GigaOM/legacy-pro/issues/3854 but i really meant https://github.com/GigaOM/legacy-pro/issues/3853.

**Updated:** addresses https://github.com/GigaOM/legacy-pro/issues/3871 
