### PR TITLE
more thorough test for an author query

### DIFF
--- a/components/class-go-sphinx.php
+++ b/components/class-go-sphinx.php
@@ -626,7 +626,7 @@ class GO_Sphinx
 	 */
 	public function sphinx_query_author( $wp_query )
 	{
-		if ( ! $wp_query->is_author )
+		if ( ! $wp_query->is_author || ( ! $wp_query->get( 'author' ) && ! $wp_query->get( 'author_name' ) ) )
 		{
 			return NULL;
 		}


### PR DESCRIPTION
also check the value of `$wp_query->author` and `$wp_query->author_name` in addition to `$wp_query->is_author` when determining whether we have an author query on our hands or not.

related to https://github.com/GigaOM/gigaom/issues/4904
